### PR TITLE
Add links for resources and our own curriculum fork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,9 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.3.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.1)
       listen (~> 3.0)
     kramdown (1.9.0)
     liquid (3.0.6)
@@ -22,12 +22,12 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
-    rb-fsevent (0.9.6)
+    rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.21)
 
 PLATFORMS
   ruby
@@ -36,4 +36,4 @@ DEPENDENCIES
   jekyll
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ title: Clojure Programming Workshops
         <h3>Useful links and tutorials:</h3>
         <ul>
           <li>
-            <p>During the workshop we use the <a href="https://clojurebridge.github.io/curriculum/#/">ClojureBridge curriculum</a> and build a <a href="https://github.com/quil/quil">Quil</a> app.</p>
+            <p>During the workshop we use the <a href="https://clojurebridge-berlin.github.io/curriculum/">ClojureBridge curriculum</a> and build a <a href="https://github.com/quil/quil">Quil</a> app.</p>
           </li>
           <li>
             <p>If you can't wait to learn Clojure <a href="http://www.tryclj.com/">try some here.</a></p>
@@ -126,7 +126,7 @@ title: Clojure Programming Workshops
         <h3>Nützliche Links und Tutorials:</h3>
         <ul>
           <li>
-            <p>Während des Workshops nutzen wir den <a href="https://clojurebridge.github.io/curriculum/#/">ClojureBridge Curriculum</a> und programmieren eine <a href="https://github.com/quil/quil">Quil</a> App.</p>
+            <p>Während des Workshops nutzen wir den <a href="https://clojurebridge-berlin.github.io/curriculum/">ClojureBridge Curriculum</a> und programmieren eine <a href="https://github.com/quil/quil">Quil</a> App.</p>
           </li>
           <li>
             <p>Falls du es nicht erwarten kannst, Clojure zu lernen, <a href="http://www.tryclj.com/">probiere es mal hier.</a></p>

--- a/index.html
+++ b/index.html
@@ -129,13 +129,13 @@ title: Clojure Programming Workshops
               <a href="http://clojurescriptkoans.com/">Interactive ClojureScript Tutorial</a>
             </li>
             <li>
-              <a href="https://aphyr.com/posts/301-clojure-from-the-ground-up-welcome">Guide to Clojure (English)</a>
+              <a href="https://aphyr.com/posts/301-clojure-from-the-ground-up-welcome">Guide to Clojure</a>
             </li>
             <li>
               <a href="http://www.4clojure.com/">Coding Challenges</a>
             </li>
             <li>
-              <a href="http://www.braveclojure.com/introduction/">Free beginner-friendly Book (English)</a>
+              <a href="http://www.braveclojure.com/introduction/">Free beginner-friendly Book</a>
             </li>
           </ul>
         </div>

--- a/index.html
+++ b/index.html
@@ -96,58 +96,66 @@ title: Clojure Programming Workshops
   <div class="container">
     <div class="row bottom-space">
       <h2>Material</h2>
-      <div class="col-md-6">
-        <h3>Useful links and tutorials:</h3>
-        <ul>
-          <li>
-            <p>During the workshop we use the <a href="https://clojurebridge-berlin.github.io/curriculum/">ClojureBridge curriculum</a> and build a <a href="https://github.com/quil/quil">Quil</a> app.</p>
-          </li>
-          <li>
-            <p>If you can't wait to learn Clojure <a href="http://www.tryclj.com/">try some here.</a></p>
-          </li>
-          <li>
-            <p>Or walk along the path of enlightenment to <a href="http://clojurescriptkoans.com/">ClojureScript.</a>
-            </p>
-          </li>
-          <li><p>Slides for the <a href="https://clojurebridge-berlin.github.io/ClojureBridgeBerlin_Intro_Talk.pdf">intro talk 2015.</a></p></li>
-          <li>
-            <p>Slides for the <a href="https://clojurebridge-berlin.github.io/coaches_training.deck.html">coaches training 2015.</a>
-            </p>
-          </li>
-          <li>
-            <p>You are welcome to join the <a href="http://clojureverse.org/">Clojureverse Forum.</a></p>
-          </li>
-          <li>
-            <p>Or the <a href="http://clojurians.net/">Clojurians Slack Chat Channel.</a></p>
-          </li>
-        </ul>
-      </div>
-      <div class="col-md-6">
-        <h3>Nützliche Links und Tutorials:</h3>
-        <ul>
-          <li>
-            <p>Während des Workshops nutzen wir den <a href="https://clojurebridge-berlin.github.io/curriculum/">ClojureBridge Curriculum</a> und programmieren eine <a href="https://github.com/quil/quil">Quil</a> App.</p>
-          </li>
-          <li>
-            <p>Falls du es nicht erwarten kannst, Clojure zu lernen, <a href="http://www.tryclj.com/">probiere es mal hier.</a></p>
-          </li>
-          <li>
-            <p>Oder probiere <a href="http://clojurescriptkoans.com/">ClojureScript.</a>
-            </p>
-          </li>
-          <li><p>Die Folien des <a href="https://clojurebridge-berlin.github.io/ClojureBridgeBerlin_Intro_Talk.pdf">Einführungsvortrages 2015.</a></p></li>
-          <li>
-            <p>Die Folien des <a href="https://clojurebridge-berlin.github.io/coaches_training.deck.html">Coaches Training 2015.</a>
-            </p>
-          </li>
-          <li>
-            <p>Sei willkommen im <a href="http://clojureverse.org/">Clojureverse Forum</a> (Englisch).</p>
-          </li>
-          <li>
-            <p>Oder im <a href="http://clojurians.net/">Clojurians Slack Chat Channel</a> (Englisch).</p>
-          </li>
-        </ul>
-      </div>
+       <div class="col-md-6">
+        <p>This is our collection of usefull links to our curriculum, files and tutorials.</p>
+        </div>
+        <div class="col-md-6">
+          <p>Hier findest du nützliche Links zu unserem Curriculum, unseren Dateien und weiteren Tutorials.</p>
+        </div>
+        <div class="col-md-4">
+          <h3>Workshop</h3>
+          <ul>
+            <li>
+              <a href="https://clojurebridge-berlin.github.io/curriculum/">Curriculum 2016</a>
+            </li>
+            <li>
+              <a href="https://github.com/quil/quil">Quil</a>
+            </li>
+            <li>
+              <a href="https://clojurebridge-berlin.github.io/ClojureBridgeBerlin_Intro_Talk.pdf">Intro Talk 2015</a>
+            </li>
+            <li>
+              <a href="https://clojurebridge-berlin.github.io/coaches_training.deck.html">Coaches Training 2015</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h3>Continue learning</h3>
+          <ul>
+            <li>
+              <a href="http://www.tryclj.com/">Interactive Clojure Tutorial</a>
+            </li>
+            <li>
+              <a href="http://clojurescriptkoans.com/">Interactive ClojureScript Tutorial</a>
+            </li>
+            <li>
+              <a href="https://aphyr.com/posts/301-clojure-from-the-ground-up-welcome">Guide to Clojure (English)</a>
+            </li>
+            <li>
+              <a href="http://www.4clojure.com/">Coding Challenges</a>
+            </li>
+            <li>
+              <a href="http://www.braveclojure.com/introduction/">Free beginner-friendly Book (English)</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h3>Community</h3>
+          <ul>
+            <li>
+              <a href="http://clojureverse.org/">Clojureverse Forum</a>
+            </li>
+            <li>
+              <a href="http://clojurians.net/">Clojurians Slack Chat Channel</a>
+            </li>
+            <li>
+              <a href="http://www.meetup.com/de-DE/Clojure-Berlin/">Clojure Meetup</a>
+            </li>
+            <li>
+              <a href="http://www.clojured.de/">ClojureD Conference Berlin</a>
+            </li>
+          </ul>
+        </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This will clean links up and add links from issue https://github.com/clojurebridge-berlin/clojurebridge-berlin.github.io/issues/9 to our website. In order to be easily accessible.

Todo:
- [x] Add curriculum link
- [x] Add `continue learning` section with links from issue

@plexus may I ask you take a look later? :blush: 
