### PR TITLE
Add a signup form for the mailchimp announce list

### DIFF
--- a/_includes/announcement_list_signup_form.html
+++ b/_includes/announcement_list_signup_form.html
@@ -1,0 +1,36 @@
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="//github.us12.list-manage.com/subscribe/post?u=d788f0653a3e56a367e673beb&amp;id=253a66d08d" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+	<h2>Subscribe to our announcement list</h2>
+<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+<div class="mc-field-group">
+	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+</label>
+	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div class="mc-field-group">
+	<label for="mce-FNAME">First Name </label>
+	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+</div>
+<div class="mc-field-group">
+	<label for="mce-LNAME">Last Name </label>
+	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+</div>
+	<div id="mce-responses" class="clear">
+		<div class="response" id="mce-error-response" style="display:none"></div>
+		<div class="response" id="mce-success-response" style="display:none"></div>
+	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d788f0653a3e56a367e673beb_253a66d08d" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+
+<!--End mc_embed_signup-->

--- a/_includes/announcement_list_signup_form_slim.html
+++ b/_includes/announcement_list_signup_form_slim.html
@@ -1,0 +1,20 @@
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="//github.us12.list-manage.com/subscribe/post?u=d788f0653a3e56a367e673beb&amp;id=253a66d08d" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+	<!-- <label for="mce-EMAIL">Subscribe to our announcement list</label> -->
+	<Input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d788f0653a3e56a367e673beb_253a66d08d" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+
+<!--End mc_embed_signup-->

--- a/_includes/announcement_list_signup_form_slim.html
+++ b/_includes/announcement_list_signup_form_slim.html
@@ -1,20 +1,21 @@
 <!-- Begin MailChimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
-	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
-	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-</style>
-<div id="mc_embed_signup">
-<form action="//github.us12.list-manage.com/subscribe/post?u=d788f0653a3e56a367e673beb&amp;id=253a66d08d" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<div class="row">
+  <form action="//github.us12.list-manage.com/subscribe/post?u=d788f0653a3e56a367e673beb&amp;id=253a66d08d" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
-	<!-- <label for="mce-EMAIL">Subscribe to our announcement list</label> -->
-	<Input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d788f0653a3e56a367e673beb_253a66d08d" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+      <!-- <label for="mce-EMAIL">Subscribe to our announcement list</label> -->
+      <div class="col-md-6">
+      <Input type="email" value="" name="EMAIL" class="email form-control" id="mce-EMAIL" placeholder="Email" required>
+      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      </div>
+      <div style="position: absolute; left: -5000px;" aria-hidden="true">
+        <input type="text" name="b_d788f0653a3e56a367e673beb_253a66d08d" tabindex="-1" value="">
+      </div>
+      <div class="col-md-6">
+        <div class="clear">
+          <input type="submit" value="Subscribe - Abonnieren" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
+        </div>
+      </div>
     </div>
-</form>
+  </form>
 </div>
-
 <!--End mc_embed_signup-->

--- a/assets/stylesheet.css
+++ b/assets/stylesheet.css
@@ -105,25 +105,24 @@ section.module.parallax-4 {
   opacity: 0.9;
 }
 
-.apply-box {
+.attention-box {
   margin-left: 5px;
   margin-right: 5px;
   padding-top: 15px;
+  padding-bottom: 5px;
   border-style: dotted;
+}
+
+.green-border {
   border-color: #5cb85c;
 }
 
-.apply-text {
-  line-height: 1.8;
+.gray-border {
+  border-color: #AEAFAE;
 }
 
-#signup-form-wrapper {
-  margin: 0 auto;
-  width: 60%;
-}
-
-#signup-form-wrapper #mc_embed_signup input.email {
-  width: 100%;
+.box-text {
+  line-height: 1.6;
 }
 
 /* Override Bootstrap */

--- a/assets/stylesheet.css
+++ b/assets/stylesheet.css
@@ -117,6 +117,15 @@ section.module.parallax-4 {
   line-height: 1.8;
 }
 
+#signup-form-wrapper {
+  margin: 0 auto;
+  width: 60%;
+}
+
+#signup-form-wrapper #mc_embed_signup input.email {
+  width: 100%;
+}
+
 /* Override Bootstrap */
 
 .btn {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: Clojure Programming Workshops
 
     <div class="row attention-box gray-border">
       <div class="col-md-3">
-        <p class="box-text"><strong>Updates & Newsletter:</strong></p>
+        <p class="box-text"><strong>News Mailing List:</strong></p>
       </div>
 
       <div class="col-md-9">

--- a/index.html
+++ b/index.html
@@ -9,15 +9,28 @@ title: Clojure Programming Workshops
       <h2>Clojure Programming Workshops</h2>
       <div class="col-md-6 space-below">
         <p>
-          <b>English: </b> <a href="http://www.clojurebridge.org/">ClojureBridge</a> is a free Clojure programming workshop for women. Especially for those with just a little or no programming experience. <br></b><b>Next workshop: January 22 and 23, 2016 in Berlin. Applications are closed.</b>
+          <b>English: </b> <a href="http://www.clojurebridge.org/">ClojureBridge</a> is a free Clojure programming workshop for women. Especially for those with just a little or no programming experience. The last workshop took place in January 2016.
         </p>
       </div>
       <div class="col-md-6">
         <p>
-          <b>Deutsch: </b><a href="http://www.clojurebridge.org/">ClojureBridge</a> ist ein kostenloser Programmier-Workshop für Frauen. Besonders für diejenigen mit keiner oder wenig Erfahrung im Programmieren. <br><b>Nächster Workshop: 22. und 23. Januar in Berlin. Die Bewerbungszeit ist zu Ende.</b>
+          <b>Deutsch: </b><a href="http://www.clojurebridge.org/">ClojureBridge</a> ist ein kostenloser Programmier-Workshop für Frauen. Besonders für diejenigen mit keiner oder wenig Erfahrung im Programmieren. Der letzte Workshop fand im Januar 2016 statt.
         </p>
       </div>
     </div>
+
+    <div class="row newsletter-box">
+      <div class="col-md-3">
+        <p><strong>Updates & Newsletter:</strong></p>
+      </div>
+
+      <div class="col-md-9">
+        <div id="signup-form-wrapper">
+          {% include announcement_list_signup_form_slim.html %}
+        </div>
+      </div>
+    </div>
+
     <div class="row arrow">
       <p>
         <b>Learn more!</b>
@@ -43,7 +56,7 @@ title: Clojure Programming Workshops
         <p><b>Workshop facts:</b></p>
         <ul>
           <li>
-            <p>Date: January 22 and 23, 2016 in Berlin</p>
+            <p>Location: Berlin</p>
           </li>
           <li>
             <p>Friday: evening from 6 PM - install party</p>
@@ -66,7 +79,7 @@ title: Clojure Programming Workshops
         <p><b>Workshop Fakten:</b></p>
         <ul>
           <li>
-            <p>Datum: 22. und 23. Januar 2016 in Berlin</p>
+            <p>Ort: Berlin</p>
           </li>
           <li>
             <p>Freitag: abends ab 18 Uhr - install party</p>
@@ -330,12 +343,4 @@ title: Clojure Programming Workshops
         </p>
       </div>
     </div>
-
-    <div class="row">
-      <div id="signup-form-wrapper" class="centered">
-        <h2>Stay up to date</h2>
-        {% include announcement_list_signup_form_slim.html %}
-      </div>
-    </div>
-
 </section>

--- a/index.html
+++ b/index.html
@@ -230,8 +230,8 @@ title: Clojure Programming Workshops
     </div>
     <div class="row">
       <div class="col-md-6">
-        <p>Our last workshop happened on July 10 and 11 in Berlin. We had 29 students and 17 coaches. Our generous host was <a href="https://www.wunderlist.com/">Wunderlist</a> and food was provided by the wonderful caterer <a href="https://de-de.facebook.com/pages/Federica-Kreuzberg/196516887157791">Federica</a>.</p>
-        <p><i>Unser letzter Workshop fand am 10. und 11. Juli in Berlin statt. Es gab 29 TeilnehmerInnen und 17 Coaches. <a href="https://www.wunderlist.com/">Wunderlist</a> war unser großzügiger Gastgeber und <a href="https://de-de.facebook.com/pages/Federica-Kreuzberg/196516887157791">Federica</a> unser fantastisches Catering.</i></p>
+        <p>Our first workshop happened on 10 and 11 July 2015 in Berlin. We had 29 students and 17 coaches. Our generous host was <a href="https://www.wunderlist.com/">Wunderlist</a> and food was provided by the wonderful caterer <a href="https://de-de.facebook.com/pages/Federica-Kreuzberg/196516887157791">Federica</a>. The second workshop in January 2016 drew 35 attendees and 20 coaches.</p>
+        <p><i>Unser erster Workshop fand am 10. und 11. Juli 2015 in Berlin statt. Es gab 29 TeilnehmerInnen und 17 Coaches. <a href="https://www.wunderlist.com/">Wunderlist</a> war unser großzügiger Gastgeber und <a href="https://de-de.facebook.com/pages/Federica-Kreuzberg/196516887157791">Federica</a> unser fantastisches Catering.</i></p>
       </div>
       <div class="col-md-6">
         <img class="attendees-picture" src="/images/cb10.jpg">
@@ -328,6 +328,13 @@ title: Clojure Programming Workshops
       <div class="col-md-12 centered">
         <p>ClojureBridge Berlin is a chapter of <a href=" http://clojurebridge.org ">clojurebridge.org</a>.
         </p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div id="signup-form-wrapper" class="centered">
+        <h2>Stay up to date</h2>
+        {% include announcement_list_signup_form_slim.html %}
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@ title: Clojure Programming Workshops
       </div>
     </div>
 
-    <div class="row newsletter-box">
+    <div class="row attention-box gray-border">
       <div class="col-md-3">
-        <p><strong>Updates & Newsletter:</strong></p>
+        <p class="box-text"><strong>Updates & Newsletter:</strong></p>
       </div>
 
       <div class="col-md-9">


### PR DESCRIPTION
We now have a mailing list so people who like to hear about future
workshops can easily subscribe. This adds a small form at the bottom to
subscribe to this list.
