### PR TITLE
Add green apply now box to homepage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     colorator (0.1)
     ffi (1.9.10)
-    jekyll (3.0.1)
+    jekyll (3.1.2)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -16,18 +16,18 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.3.1)
       listen (~> 3.0)
-    kramdown (1.9.0)
+    kramdown (1.10.0)
     liquid (3.0.6)
-    listen (3.0.5)
+    listen (3.0.6)
       rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
+      rb-inotify (>= 0.9.7)
     mercenary (0.3.5)
     rb-fsevent (0.9.7)
-    rb-inotify (0.9.5)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rouge (1.10.1)
     safe_yaml (1.0.4)
-    sass (3.4.21)
+    sass (3.4.22)
 
 PLATFORMS
   ruby

--- a/assets/stylesheet.css
+++ b/assets/stylesheet.css
@@ -113,6 +113,18 @@ section.module.parallax-4 {
   border-style: dotted;
 }
 
+.apply-box {
+  margin-left: 5px;
+  margin-right: 5px;
+  padding-top: 15px;
+  border-style: dotted;
+  border-color: #5cb85c;
+}
+
+.apply-text {
+  line-height: 1.6;
+}
+
 .green-border {
   border-color: #5cb85c;
 }

--- a/index.html
+++ b/index.html
@@ -9,25 +9,35 @@ title: Clojure Programming Workshops
       <h2>Clojure Programming Workshops</h2>
       <div class="col-md-6 space-below">
         <p>
-          <b>English: </b> <a href="http://www.clojurebridge.org/">ClojureBridge</a> is a free Clojure programming workshop for women. Especially for those with just a little or no programming experience. The last workshop took place in January 2016.
+          <b>English: </b> <a href="http://www.clojurebridge.org/">ClojureBridge</a>
+          is a free Clojure programming workshop for women. Especially for those with
+          just a little or no programming experience.
+          <b>The next workshop is on Friday June 17, and Saturday June 18, 2016.</b>
         </p>
       </div>
       <div class="col-md-6">
         <p>
-          <b>Deutsch: </b><a href="http://www.clojurebridge.org/">ClojureBridge</a> ist ein kostenloser Programmier-Workshop für Frauen. Besonders für diejenigen mit keiner oder wenig Erfahrung im Programmieren. Der letzte Workshop fand im Januar 2016 statt.
+          <b>Deutsch: </b><a href="http://www.clojurebridge.org/">ClojureBridge</a>
+          ist ein kostenloser Programmier-Workshop für Frauen. Besonders für diejenigen
+          mit keiner oder wenig Erfahrung im Programmieren.
+          <b>Der nächste Workshop findet am 17. und 18. Juni 2016 statt.</b>
         </p>
       </div>
     </div>
 
-    <div class="row attention-box gray-border">
-      <div class="col-md-3">
-        <p class="box-text"><strong>News Mailing List:</strong></p>
+    <div class="row apply-box">
+      <div class="col-xs-12 col-sm-12 col-md-4">
+        <p class="apply-text">Apply now: | Bewirb dich jetzt:</p>
       </div>
-
-      <div class="col-md-9">
-        <div id="signup-form-wrapper">
-          {% include announcement_list_signup_form_slim.html %}
-        </div>
+      <div class="col-xs-12 col-sm-12 col-md-4">
+        <a href="">
+          <button type="button" class="btn btn-success">ATTEND | TEILNEHMEN</button>
+        </a>
+      </div>
+      <div class="col-xs-12 col-sm-12 col-md-4">
+        <a href="">
+          <button type="button" class="btn btn-default coach-button">COACH</button>
+        </a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ title: Clojure Programming Workshops
         </a>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-4">
-        <a href="">
+        <a href="http://goo.gl/forms/zg113VqIoy">
           <button type="button" class="btn btn-default coach-button">COACH</button>
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ title: Clojure Programming Workshops
         <p class="apply-text">Apply now: | Bewirb dich jetzt:</p>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-4">
-        <a href="">
+        <a href="http://goo.gl/forms/UbTCvL6jZb">
           <button type="button" class="btn btn-success">ATTEND | TEILNEHMEN</button>
         </a>
       </div>


### PR DESCRIPTION
This PR add the green application box with 2 buttons for signup as coach and attendee.
![screen shot 2016-04-02 at 18 39 54](https://cloud.githubusercontent.com/assets/5123681/14227635/61bc732c-f902-11e5-9568-48eecbeeecf6.png)

TODO
- [x] Add attendee link to application form before merging
- [x] Add coach link to application form before merging

After the applications are closed we can insert the newsletter markup again. I documented it in the wiki:
https://github.com/clojurebridge-berlin/clojurebridge-berlin.github.io/wiki/Apply-and-Newsletter-Box
