### PR TITLE
Updating sponsorship page to include tiers

### DIFF
--- a/sponsor_us.md
+++ b/sponsor_us.md
@@ -55,8 +55,9 @@ the number of sign-ups.
 
 Alternatively, we also take donations via the
 [Travis Foundation UG](http://foundation.travis-ci.org/), a registered
-not-for-profit company (a “Gemeinnützige Organisation” under German law). The 
-Travis Foundation can issue a Donation Receipt for accounting and tax deduction. It
+not-for-profit company (a “Gemeinnützige Organisation” under German law). This 
+is how we can take the small supporter tier, for donations from 250€. The Travis 
+Foundation can issue a Donation Receipt for accounting and tax deduction. It
 does *not* issue invoices for donations.
 
 Get in touch today at <clojurebridge.berlin@gmail.com>.

--- a/sponsor_us.md
+++ b/sponsor_us.md
@@ -21,7 +21,7 @@ Your company has an option of different tiers of support. There's the direct
 sponsorship tiers, which are the most valuable form of support, and a generic
 small supporter tier. The direct sponsorship tiers involve directly paying our
 supplier with the order details we provide, and as such also mean you can pay
-with credit card will and receive an invoice.
+with credit card and will receive an invoice.
 
 * Platinum tier (~600€): Food for the main event 
 * Gold Tier (~500€): Notebooks for the Attendees 

--- a/sponsor_us.md
+++ b/sponsor_us.md
@@ -7,7 +7,7 @@ permalink: /sponsor-us/
 # Sponsor Us
 
 ClojureBridge Berlin organizes free programming workshops for members of
-underrepresented groups. All organizers, teachers, and assistants volunteer a
+underrepresented groups. All organizers, coaches, and assistants volunteer a
 part of their free time. To cover costs we rely on the generous patronage of
 companies that support us in our cause.
 
@@ -17,40 +17,46 @@ By supporting us you help to make the world a little better. Your company also
 gets to associate itself with a positive and ambitious event, which aims to
 increase diversity in the technology scene.
 
-Sponsors are listed on our website and on our event page on ClojureBridge.org.
-They receive a shoutout at the start and end of the event, and receive a warm
-"thank you" on our social media account. We also list sponsors by name on our
-popular t-shirts that are handed out to teachers and attendees, and provide the
-opportunity to offer "swag" (stickers, note books, thumb drives, etc.) at the
-event.
+Your company has an option of different tiers of support. There's the direct
+sponsorship tiers, which are the most valuable form of support, and a generic
+small supporter tier. The direct sponsorship tiers involve directly paying our
+supplier with the order details we provide, and as such also mean you can pay
+with credit card will and receive an invoice.
+
+* Platinum tier (~600€): Food for the main event 
+* Gold Tier (~500€): Notebooks for the Attendees 
+* Silver Tier (~400€): Food for the coaches training
+* Small Supporter Tier (250€)
+
+All our sponsors are listed on our website and on our event page on 
+ClojureBridge.org. They'll receive a shoutout at the start and end of the event
+along with their logos in our presentations. All our sponsors will also have
+the opportunity to offer "swag" (stickers, note books, thumb drives, etc.) at 
+the event.
+
+Additionally, those who sponsored in our top three tiers will also get special
+shoutouts on our social media accounts, along with priority placements of their
+logos.
+
 
 ## Financial
 
-To handle donations we work with
+There's two ways your company can choose to support us:
+### Direct Sponsorship
+If you've opted for a direct sponsorship tier, then your transaction will be with
+our suppliers directly. In this case, we will give you the exact
+link/message/order that we need, and you make the transaction with that
+company directly. This means normal business billing, with ability to pay by
+credit card, and get an invoice. However, due to the nature of the process,
+we can't predict the exact amount — it would depend on factors such as the
+the number of sign-ups.
+
+### Support us via donation
+
+Alternatively, we also take donations via the
 [Travis Foundation UG](http://foundation.travis-ci.org/), a registered
-not-for-profit company (a “Gemeinnützige Organisation” under German law.) Travis
-Foundation can issue a Donation Receipt for accounting and tax deduction. It
+not-for-profit company (a “Gemeinnützige Organisation” under German law). The 
+Travis Foundation can issue a Donation Receipt for accounting and tax deduction. It
 does *not* issue invoices for donations.
 
-As a sponsor you can also choose to directly pick up the bill for one of our
-expenses, in which case we let the supplier invoice your company directly. This
-can be a great way to make your contribution more concrete and visible ("thank
-you Foocorp Inc. for the lovely t-shirts!"). Keep in mind that in this case we
-might not be able to predict up front the exact amount invoiced, it could for
-instance depend on the amount of sign-ups.
-
-## Budget
-
-This is an example budget based on previous workshops:
-
-* T-shirts: € 655
-* Catering workshop: € 500
-* Catering installfest: € 360
-* Catering coaches training: € 75
-* Breakfast € 100
-* Afternoon snacks € 100
-* Drinks: € 280
-* Stickers € 90
-* Small costs (tags, postage, pens): € 30
-
-Get in touch today at Clojurebridge.Berlin (at) gmail.com.
+Get in touch today at <clojurebridge.berlin@gmail.com>.


### PR DESCRIPTION
I've called them Platinum, Gold, and Silver — given these are common names for funding tiers. Most of the text has been kept intact, with some rewording, and removing of various stuff that's no longer relevant. Donations types have been made more explicit, hopefully highlighting the fact that invoices are not given for the Travis Foundation donations. 

Feedback and corrections more than welcome.
