### PR TITLE
Simplify sponsor page

### DIFF
--- a/sponsor_us.md
+++ b/sponsor_us.md
@@ -19,22 +19,21 @@ increase diversity in the technology scene.
 
 Your company has an option of different tiers of support:
 
-### Platinum Sponsor - 600€
-* e.g. lunch on workshop day
-* Your logo in top placement on our website
+### Platinum Sponsor - 600+€
+* _e.g. by paying for lunch on workshop day_
 * Shoutout on our social media pages
-* You can offer swag for our attendees
+* Your logo in **top** placement on our website
+* Announcement at the event (you may offer swag for attendees)
 
 ### Gold Sponsor - 500€
-* e.g. swag for the attendees
+* _e.g. by buying t-shirts for the attendees_
 * Your logo on our website
-* Shoutout on our social media pages
-* You can offer swag for our attendees
+* Announcement at the event (you may offer swag for attendees)
 
 ### Small Supporter - 250€
-* e.g. coffee & cake on workshop day
+* _e.g. by sponsoring coffee & cake on workshop day_
 * Your logo on our website
-* You can offer swag for our attendees
+* Announcement at the event (you may offer swag for attendees)
 
 ## How does it work?
 
@@ -42,7 +41,7 @@ There's two ways your company can choose to support us:
 
 ### Direct Sponsorship
 
-If you've opted for a direct sponsorship (only for Platinum or Gold sponsors), then your transaction will be with
+If you've opted for a direct sponsorship (only available for Platinum or Gold sponsors), then your transaction will be with
 our suppliers directly. In this case, we will give you the exact
 link/message/order that we need, and you make the transaction with that
 company directly. This means normal business billing, with ability to pay by

--- a/sponsor_us.md
+++ b/sponsor_us.md
@@ -17,35 +17,32 @@ By supporting us you help to make the world a little better. Your company also
 gets to associate itself with a positive and ambitious event, which aims to
 increase diversity in the technology scene.
 
-Your company has an option of different tiers of support. There's the direct
-sponsorship tiers, which are the most valuable form of support, and a generic
-small supporter tier. The direct sponsorship tiers involve directly paying our
-supplier with the order details we provide, and as such also mean you can pay
-with credit card and will receive an invoice.
+Your company has an option of different tiers of support:
 
-* Platinum Tier (~600€): Food for the main event
-* Gold Tier (~500€): Notebooks for the Attendees
-* Silver Tier (~400€): Food for the coaches training
-* Small Supporter Tier (250€)
+### Platinum Sponsor - 600€
+* e.g. lunch on workshop day
+* Your logo in top placement on our website
+* Shoutout on our social media pages
+* You can offer swag for our attendees
 
-All our sponsors are listed on our website and on our event page on
-ClojureBridge.org. They'll receive a shoutout at the start and end of the event
-along with their logos in our presentations. All our sponsors will also have
-the opportunity to offer "swag" (stickers, note books, thumb drives, etc.) at
-the event.
+### Gold Sponsor - 500€
+* e.g. swag for the attendees
+* Your logo on our website
+* Shoutout on our social media pages
+* You can offer swag for our attendees
 
-Additionally, those who sponsored in our top three tiers will also get special
-shoutouts on our social media accounts, along with priority placements of their
-logos.
+### Small Supporter - 250€
+* e.g. coffee & cake on workshop day
+* Your logo on our website
+* You can offer swag for our attendees
 
-
-## Financial
+## How does it work?
 
 There's two ways your company can choose to support us:
 
 ### Direct Sponsorship
 
-If you've opted for a direct sponsorship tier, then your transaction will be with
+If you've opted for a direct sponsorship (only for Platinum or Gold sponsors), then your transaction will be with
 our suppliers directly. In this case, we will give you the exact
 link/message/order that we need, and you make the transaction with that
 company directly. This means normal business billing, with ability to pay by


### PR DESCRIPTION
As listed here: https://github.com/clojurebridge-berlin/clojurebridge-berlin.github.io/issues/30

the intention is to simplify the page and more clearly list what each level of payment gets you 

I also tried to remove the association that all Gold/Platinum _must_ be direct sponsorships - does that make sense? In my understanding those tiers are primarily about the amout of $ not about the //direct sponsorship// - and I tried to clarify that by changing the "you pay for...." to "you may for example (e.g.) pay for lunch". That way we're not tied to having e.g. only 1 gold sponsors and can divide the money how it makes sense to us. 

Plus, I tried to remove the word "tier" cause I think it confuses Germans 😹 
