### PR TITLE
Fix typos and omissions

### DIFF
--- a/coaches_training.deck.html
+++ b/coaches_training.deck.html
@@ -464,7 +464,7 @@ Floating coaches are available for extra support.</p>
 <li>ClojureBridge normally makes a distinction between coaches and TAs (teaching assistants).</li>
 <li>We will try to form groups with two coaches per group.</li>
 <li>You can decide on one coach to take the lead, or you can tag-team.</li>
-<li>There will also be some "floating" TAs that can go around ang help.</li>
+<li>There will also be some "floating" TAs that can go around and help.</li>
 </ul>
 
 </section>

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -48,7 +48,7 @@ Raise your hand if you've been to a workshop before!
 
 * First workshop April 2014
 * Since then over 40 workshops in the US, UK, Ireland, Australia, Scotland, Finland, Sweden, Brazil, Canada, and... Germany!
-* So far two workshops in Berlin: July 2015, January 2016, and now the third one coming up! 🎉
+* Workshops in Berlin since July 2015 and recurring regularly! 🎉
 
 # How does a workshop work?
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -291,7 +291,7 @@ DISCUSS!
 * ClojureBridge normally makes a distinction between coaches and TAs (teaching assistants).
 * We will try to form groups with two coaches per group.
 * You can decide on one coach to take the lead, or you can tag-team.
-* There will also be some "floating" TAs that can go around ang help.
+* There will also be some "floating" TAs that can go around and help.
 
 # Coaching Dynamics (Ideas)
 


### PR DESCRIPTION
I fixed the "ang help" typo and corrected the slide that omitted the most recent ClojureBridge event. Hope this helps.