### PR TITLE
Separate registration info for participants and coaches

### DIFF
--- a/assets/stylesheet.css
+++ b/assets/stylesheet.css
@@ -1,4 +1,4 @@
-h1, h2 {
+h1, h2, h3 {
   text-align: center;
 }
 
@@ -14,6 +14,15 @@ h1 {
 section.module h2 {
   margin-bottom: 40px;
   font-size: 30px;       /* font size on tablet and smaller */
+}
+
+h3 {
+  font-size: 32px;
+  margin-bottom: 30px;
+}
+
+.btn {
+  font-size: 20px;
 }
 
 section.module p {
@@ -119,16 +128,14 @@ section.module.parallax-4 {
   border-style: dotted;
 }
 
-.apply-box {
-  margin-left: 5px;
-  margin-right: 5px;
-  padding-top: 15px;
-  border-style: dotted;
-  border-color: #5cb85c;
+.container-registration {
+  margin: 50px auto;
+  padding: 30px 40px 10px;
+  border: 4px solid black;
 }
 
-.apply-text {
-  line-height: 1.6;
+.btn-wide {
+  width: 100%;
 }
 
 .green-border {
@@ -141,13 +148,6 @@ section.module.parallax-4 {
 
 .box-text {
   line-height: 1.6;
-}
-
-/* Override Bootstrap */
-
-.btn {
-  margin-bottom: 10px;
-  width: 100%;
 }
 
 /* MEDIA QUERIES */

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ title: Clojure Programming Workshops
           <b>Deutsch:</b> Nächster Workshop: Freitagabend <strong>6 Oktober</strong> und Samstag <strong>7 Oktober</strong>.
         </p>
         <p class="centered">
-          <a href="https://goo.gl/forms/j2uSR4etb1maX3u52"><button type="button" class="btn btn-success btn-wide">Teilnehmen</button></a>
+          <a href="https://goo.gl/forms/j2uSR4etb1maX3u52"><button type="button" class="btn btn-success btn-wide">Bewirb dich jetzt</button></a>
         </p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -6,45 +6,67 @@ title: Clojure Programming Workshops
 <section class="module content">
   <div class="container">
     <div class="row">
-      <h2>Clojure Programming Workshops</h2>
-      <div class="col-md-6 space-below">
+      <div class="col-sm-6 col-md-6 space-below">
         <p>
-          <b>English: </b> <a href="http://www.clojurebridge.org/">ClojureBridge</a>
-          is a free Clojure programming workshop for women and non-binary people -
-          especially for those with little to no programming experience.<br>
-          <b>Next workshop: 6/7 October 2017</b>
+          <b>English:</b> ClojureBridge is a free workshop introducing women and non-binary people to programming and the local technology community.
         </p>
       </div>
-      <div class="col-md-6">
+      <div class="col-sm-6 col-md-6">
         <p>
-          <b>Deutsch: </b><a href="http://www.clojurebridge.org/">ClojureBridge</a>
-          ist ein kostenloser Programmier-Workshop für Frauen und nicht-binäre Menschen, besonders für diejenigen
+          <b>Deutsch:</b> ClojureBridge ist ein kostenloser Programmier-Workshop für Frauen und nicht-binäre Menschen, besonders für diejenigen
           mit keiner oder wenig Erfahrung im Programmieren.<br>
-          <b>Nächster Workshop: 6/7 Oktober 2017</b>
         </p>
       </div>
-    </div>
-    <div class="row apply-box">
-      <div class="col-xs-12 col-sm-12 col-md-4">
-        <p class="apply-text">Apply now: | Bewirb dich jetzt:</p>
-      </div>
-      <div class="col-xs-12 col-sm-12 col-md-4">
-        <a href="https://goo.gl/forms/j2uSR4etb1maX3u52"><button type="button" class="btn btn-success">ATTEND | TEILNEHMEN</button></a>
-      </div>
-      <div class="col-xs-12 col-sm-12 col-md-4">
-        <a href="https://goo.gl/forms/YMgTqhgQ0Ko1PNht1"><button type="button" class="btn btn-default coach-button">COACH</button></a>
-      </div>
-    </div>
-    <div class="row"><div class="col-md-12"><small>Application deadline |  Bewerbungsschluss September 10</small></div></div>
-
-    <div class="row arrow">
-      <p>
-        <b>Learn more!</b>
-        <img src="/images/scroll-arrow.png">
-        <b>Erfahre mehr!</b>
-      </p>
     </div>
   </div>
+
+  <div class="container container-registration">
+    <div class="row">
+      <h3>ClojureBridge 2017</h3>
+    </div>
+
+    <div class="row">
+      <div class="col-xs-12 col-sm-6 col-md-6 bottom-space">
+        <p>
+          <b>English:</b> Our next workshop is Friday evening <strong>6 October</strong> and Saturday <strong>7 October</strong>. Join the Berlin Clojure community for a day of learning and exploration through creative visual projects!
+        </p>
+        <p class="centered">
+          <a href="https://goo.gl/forms/j2uSR4etb1maX3u52"><button type="button" class="btn btn-success btn-wide">Register now</button></a>
+        </p>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-6 bottom-space">
+        <p>
+          <b>Deutsch:</b> Nächster Workshop: Freitagabend <strong>6 Oktober</strong> und Samstag <strong>7 Oktober</strong>.
+        </p>
+        <p class="centered">
+          <a href="https://goo.gl/forms/j2uSR4etb1maX3u52"><button type="button" class="btn btn-success btn-wide">Teilnehmen</button></a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="row">
+      <h3>Call for Coaches</h3>
+    </div>
+    <div class="row">
+      <div class="col-xs-12 col-sm-6 col-md-6 bottom-space">
+        <p>
+          <b>English:</b> Do you enjoy programming and want to help spread the joy of coding or Clojure? Sign up to <a href="http://clojurebridge-berlin.org/coach">coach at ClojureBridge</a>! All genders welcome. If you are considering but don’t feel confident enough, don’t worry, you <em>can</em> coach. We will help you.
+        </p>
+        <p class="centered">
+          <a href="https://goo.gl/forms/YMgTqhgQ0Ko1PNht1"><button type="button" class="btn btn-default btn-wide coach-button">Register to Coach</button></a>
+        </p>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-6 bottom-space">
+        <p>
+          <b>Deutsch:</b> Sie programmieren und wollen die Freude an der Codierung oder Clojure teilen? Melden Sie <a href="http://clojurebridge-berlin.org/coach">sich bei ClojureBridge an Trainer</a>! Alle Geschlechter willkommen Wenn Sie erwägen, aber nicht sicher genug zu sein, keine Sorge, können Sie Trainer. Wir werden Ihnen helfen.
+        </p>
+        <p class="centered">
+          <a href="https://goo.gl/forms/YMgTqhgQ0Ko1PNht1"><button type="button" class="btn btn-default btn-wide coach-button">Teilnehmen sich an Coach</button></a>
+        </p>
+      </div>
+    </div>
 </section>
 
 <section class="module parallax parallax-1">


### PR DESCRIPTION
Unraveling the registration section to separate info for participants vs coaches, making it a bit more friendly and readable. Maybe this is because I can only read English, but the dual-language buttons were pretty confusing to me. 

**I would appreciate need help with the German portion!** It probably is pretty incomprehensible :'D

Closes https://github.com/clojurebridge-berlin/clojurebridge-berlin.github.io/issues/75.

Before:

![screenshot from 2017-08-12 16-28-11](https://user-images.githubusercontent.com/1589186/29241505-6948f40c-7f7b-11e7-8034-4012dfdd418b.png)

After: (see [below](https://github.com/clojurebridge-berlin/clojurebridge-berlin.github.io/pull/71#issuecomment-322882072))