### PR TITLE
Discussion reorderings etc

### DIFF
--- a/coaches_training.deck.html
+++ b/coaches_training.deck.html
@@ -48,7 +48,7 @@
     <section class="slide" id="code_of_conduct">
 <h2>Code of Conduct</h2>
 
-<p>The Berlin Code of Conduct (<a href="berlincodeofconduct.org">berlincodeofconduct.org</a>)  outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
+<p>The Berlin Code of Conduct (<a href="berlincodeofconduct.org">berlincodeofconduct.org</a>) outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
 
 <h3>Expected Behavior</h3>
 
@@ -89,18 +89,13 @@
 <h3>Who are you?</h3>
 
 <ul>
-<li>What's your name?</li>
-<li>What are your pronouns?</li>
-<li>Have you been to a ClojureBridge or similar workshops before? How many?</li>
-<li>What's your favorite place in Berlin?</li>
-<li>What's the most non-coding thing you do?</li>
+<li>What's your name and pronouns?</li>
+<li>Have you been to a ClojureBridge or similar workshops before?</li>
 </ul>
 
 </section>
     <section class="slide" id="whats_a_clojurebridge">
 <h2>What's a ClojureBridge?</h2>
-
-<p>Raise your hand if you've been to a workshop before!</p>
 
 <h3>RailsBridge Fun Facts</h3>
 
@@ -140,7 +135,7 @@ Floating coaches are available for extra support.</p>
 
 <p>NightCode is pretty easy to install, as it's just an executable JAR. We'll have a couple thumb drives to go around.</p>
 
-<p>Please actually create and run a Quil project, so all dependencies are downloaded and available.</p>
+<p>Please actually create and run a Quil project, so all dependencies are downloaded and available – this has caused problems before!</p>
 
 <h4>Keep in mind:</h4>
 
@@ -149,6 +144,28 @@ Floating coaches are available for extra support.</p>
 <li>Even though Windows might not be your preferred development environment, we're here to encourage people and meet them wherever they are right now.</li>
 <li>Do NOT say bad things about Windows, even if it's frustrating.</li>
 <li>If you're not sure about something, grab another volunteer.</li>
+</ul>
+
+</section>
+    <section class="slide" id="on_that_note">
+<h2>On that note...</h2>
+
+<ul>
+<li>Don't be negative about technologies, even if you're certain they're the work of the devil</li>
+<li>PHP is fine, Windows is fine, VisualBasic is fine</li>
+<li>Appreciate that different technologies have different trade-offs. Being easily accessible is one of them.</li>
+</ul>
+
+</section>
+    <section class="slide" id="try_to_suppress_your_understandable_culturallyinfluenced_sexism">
+<h2>Try to suppress your (understandable) culturally-influenced sexism</h2>
+
+<ul>
+<li>Don't hit on people. No sexual advances. This extends to the after-party.</li>
+<li>Don't make sexist jokes. Or racist, classist, or ableist jokes. Call people out if they do. A simple "That's not funny" and moving on quickly with the conversation will often suffice.</li>
+<li>Don't make gender-based generalizations ("Women are better at X, because ...")</li>
+<li>Don't make references to people's bodies or state your opinion of them.</li>
+<li>Don't use slurs.</li>
 </ul>
 
 </section>
@@ -246,6 +263,66 @@ Floating coaches are available for extra support.</p>
 <p>DISCUSS!</p>
 
 </section>
+    <section class="slide" id="discussion_do_you_know_whats_up">
+<h2>Discussion (Do you know what's up?)</h2>
+
+<h4>How can you help people feel like you know what's going on?</h4>
+
+<h4>What are things you can do to help the students trust you?</h4>
+
+<h4>What are some things to avoid?</h4>
+
+<p>DISCUSS!</p>
+
+</section>
+    <section class="slide" id="discussion_technical_capability">
+<h2>Discussion: Technical Capability</h2>
+
+<h3>How can you help people feel technically capable?</h3>
+
+<h3>What kinds of insecurities might your student have?</h3>
+
+<h3>How can you bolster their confidence?</h3>
+
+<p>DISCUSS!</p>
+
+</section>
+    <section class="slide" id="discussion_challenges">
+<h2>Discussion: Challenges</h2>
+
+<p>Talk about what problems you might anticipate, and what to do about them.</p>
+
+<h4>Some issues:</h4>
+
+<ul>
+<li>Student is in the wrong class level</li>
+<li>Student is disruptive</li>
+<li>Student is disengaged</li>
+</ul>
+
+<p>DISCUSS!</p>
+
+</section>
+    <section class="slide" id="discussion_coaching">
+<h2>Discussion: Coaching</h2>
+
+<h4>What are the benefits of having two coaches in a group?</h4>
+
+<h4>How can you divide the roles between the coaches?</h4>
+
+<h4>How can you get a good dynamic between the whole team, both attendees and coaches?</h4>
+
+<p>DISCUSS!</p>
+
+</section>
+    <section class="slide" id="what_we_came_up_with">
+<h2>What we came up with</h2>
+
+<ul>
+<li>So now you've been through these discussions, this is what we came up with!</li>
+</ul>
+
+</section>
     <section class="slide" id="social_comfort_ideas">
 <h2>Social Comfort (Ideas)</h2>
 
@@ -266,18 +343,7 @@ Floating coaches are available for extra support.</p>
 
 </section>
     <section class="slide" id="social_comfort_more_ideas">
-<h2>Social Comfort (More Ideas)</h2>
-
-<h4>Try to suppress your (understandable) culturally-influenced sexism</h4>
-
-<ul>
-<li>Don't hit on people. No sexual advances. None. Even at the after-party.</li>
-<li>Don't make sexist jokes. Or racist, classist, or ableist jokes. Call people out if they do. A simple "That's not funny" and moving on quickly with the conversation will often suffice.</li>
-<li>Don't make gender-based generalizations ("Women are better at X, because ...")</li>
-<li>Don't make references to people's bodies or state your opinion of them.</li>
-<li>Don't use slurs.</li>
-</ul>
-
+<h1>Social Comfort (More Ideas)</h1>
 </section>
     <section class="slide" id="social_comfort_pay_attention_to_pronouns">
 <h2>Social Comfort (pay attention to pronouns)</h2>
@@ -288,42 +354,6 @@ Floating coaches are available for extra support.</p>
 <li>please don't assume anybody's gender</li>
 <li>refrain from gender specific terms like "hey guys", "hello ladies"</li>
 </ul>
-
-</section>
-    <section class="slide" id="social_comfort_even_more_ideas">
-<h2>Social Comfort (Even More Ideas)</h2>
-
-<h4>Represent the diverse and welcoming community we stand for</h4>
-
-<ul>
-<li>Don't mock other languages or technologies.</li>
-<li>Leave your nerdy flame wars at the door.</li>
-<li>Windows is fine. PHP is fine. Javascript is fine.</li>
-<li>Be genuinely interested in people's experiences. ("You built something? That's cool. What does it do?")</li>
-<li>Appreciate that different technologies have different trade-offs. Being easily accessible is one of them.</li>
-</ul>
-
-</section>
-    <section class="slide" id="code_of_conduct_violations">
-<h2>Code of Conduct Violations</h2>
-
-<p>The Berlin Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
-
-<h4>Q: How do I react if an attendee complains about CoC violation?</h4>
-
-<h4>A: Bring them to an orga-team member</h4>
-
-</section>
-    <section class="slide" id="discussion_technical_capability">
-<h2>Discussion: Technical Capability</h2>
-
-<h3>How can you help people feel technically capable?</h3>
-
-<h3>What kinds of insecurities might your student have?</h3>
-
-<h3>How can you bolster their confidence?</h3>
-
-<p>DISCUSS!</p>
 
 </section>
     <section class="slide" id="technical_capability_ideas">
@@ -388,18 +418,6 @@ Floating coaches are available for extra support.</p>
 </ul>
 
 </section>
-    <section class="slide" id="discussion_do_you_know_whats_up">
-<h2>Discussion (Do you know what's up?)</h2>
-
-<h4>How can you help people feel like you know what's going on?</h4>
-
-<h4>What are things you can do to help the students trust you?</h4>
-
-<h4>What are some things to avoid?</h4>
-
-<p>DISCUSS!</p>
-
-</section>
     <section class="slide" id="know_whats_up_ideas">
 <h2>Know What's Up (Ideas)</h2>
 
@@ -455,42 +473,23 @@ Floating coaches are available for extra support.</p>
 </ul>
 
 </section>
-    <section class="slide" id="discussion_challenges">
-<h2>Discussion: Challenges</h2>
+    <section class="slide" id="code_of_conduct_violations">
+<h2>Code of Conduct Violations</h2>
 
-<p>Talk about what problems you might anticipate, and what to do about them.</p>
+<p>The Berlin Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
 
-<h4>Some issues:</h4>
+<h4>Q: How do I react if an attendee complains about CoC violation?</h4>
 
-<ul>
-<li>Student is in the wrong class level</li>
-<li>Student is disruptive</li>
-<li>Student is disengaged</li>
-</ul>
-
-<p>DISCUSS!</p>
-
-</section>
-    <section class="slide" id="discussion_coaching">
-<h2>Discussion: Coaching</h2>
-
-<h4>What are the benefits of having two coaches in a group?</h4>
-
-<h4>How can you divide the roles between the coaches?</h4>
-
-<h4>How can you get a good dynamic between the whole team, both attendees and coaches?</h4>
-
-<p>DISCUSS!</p>
+<h4>A: Bring them to an orga-team member</h4>
 
 </section>
     <section class="slide" id="coaching_build_a_team">
 <h2>Coaching: Build a Team</h2>
 
 <ul>
-<li>ClojureBridge normally makes a distinction between coaches and TAs (teaching assistants).</li>
 <li>We will try to form groups with two coaches per group.</li>
 <li>You can decide on one coach to take the lead, or you can tag-team.</li>
-<li>There will also be some "floating" TAs that can go around and help.</li>
+<li>There will also be some "floating" coaches that can go around and help.</li>
 </ul>
 
 </section>
@@ -514,16 +513,31 @@ Floating coaches are available for extra support.</p>
 </ul>
 
 </section>
-    <section class="slide" id="discussion_comprehension">
-<h2>Discussion: Comprehension</h2>
+    <section class="slide" id="the_curriculum">
+<h2>The Curriculum</h2>
 
-<h4>How can you tell if they understand the words you're saying?</h4>
+<ul>
+<li>Most people will go through the curriculum on our web page</li>
+</ul>
 
-<h4>What are good questions to ask to check comprehension?</h4>
+<p><a href="http://clojurebridge-berlin.org/curriculum">http://clojurebridge-berlin.org/curriculum</a></p>
 
-<h4>What did your favorite coaches do to gauge understanding?</h4>
+<h3>It's a slideshow that goes through the concepts of:</h3>
 
-<p>DISCUSS!</p>
+<ul>
+<li>values</li>
+<li>data structures</li>
+<li>functions</li>
+<li>control logic</li>
+</ul>
+
+<h2>Please take a look :)</h2>
+
+</section>
+    <section class="slide" id="some_people_are_trialing_a_new_curriculum">
+<h2>Some people are trialing a new Curriculum</h2>
+
+<p>But everyone should still install NightCode for now</p>
 
 </section>
     <section class="slide" id="practical_recap">
@@ -569,30 +583,33 @@ Floating coaches are available for extra support.</p>
           <li><a href="#whats_a_clojurebridge">What&#39;s a ClojureBridge?</a></li>
           <li><a href="#how_does_a_workshop_work">How does a workshop work?</a></li>
           <li><a href="#installfest">Installfest!</a></li>
+          <li><a href="#on_that_note">On that note...</a></li>
+          <li><a href="#try_to_suppress_your_understandable_culturallyinfluenced_sexism">Try to suppress your (understandable) culturally-influenced sexism</a></li>
           <li><a href="#typical_clojurebridge_schedule">Typical ClojureBridge Schedule</a></li>
           <li><a href="#is_clojurebridge_open_source">Is ClojureBridge Open Source?</a></li>
           <li><a href="#is_clojurebridge_open_source">Is ClojureBridge Open Source?</a></li>
           <li><a href="#discussion_topics">Discussion Topics</a></li>
           <li><a href="#how_to_make_your_class_awesome">How to make your class awesome</a></li>
           <li><a href="#discussion_social_comfort">Discussion: Social Comfort</a></li>
+          <li><a href="#discussion_do_you_know_whats_up">Discussion (Do you know what&#39;s up?)</a></li>
+          <li><a href="#discussion_technical_capability">Discussion: Technical Capability</a></li>
+          <li><a href="#discussion_challenges">Discussion: Challenges</a></li>
+          <li><a href="#discussion_coaching">Discussion: Coaching</a></li>
+          <li><a href="#what_we_came_up_with">What we came up with</a></li>
           <li><a href="#social_comfort_ideas">Social Comfort (Ideas)</a></li>
           <li><a href="#social_comfort_more_ideas">Social Comfort (More Ideas)</a></li>
           <li><a href="#social_comfort_pay_attention_to_pronouns">Social Comfort (pay attention to pronouns)</a></li>
-          <li><a href="#social_comfort_even_more_ideas">Social Comfort (Even More Ideas)</a></li>
-          <li><a href="#code_of_conduct_violations">Code of Conduct Violations</a></li>
-          <li><a href="#discussion_technical_capability">Discussion: Technical Capability</a></li>
           <li><a href="#technical_capability_ideas">Technical Capability (Ideas)</a></li>
           <li><a href="#technical_capability_more_ideas">Technical Capability (More Ideas)</a></li>
           <li><a href="#technical_capability_even_more_ideas">Technical Capability (Even More Ideas)</a></li>
-          <li><a href="#discussion_do_you_know_whats_up">Discussion (Do you know what&#39;s up?)</a></li>
           <li><a href="#know_whats_up_ideas">Know What&#39;s Up (Ideas)</a></li>
           <li><a href="#know_whats_up_more_ideas">Know What&#39;s Up (More Ideas)</a></li>
           <li><a href="#know_whats_up_even_more_ideas">Know What&#39;s Up (Even More Ideas)</a></li>
-          <li><a href="#discussion_challenges">Discussion: Challenges</a></li>
-          <li><a href="#discussion_coaching">Discussion: Coaching</a></li>
+          <li><a href="#code_of_conduct_violations">Code of Conduct Violations</a></li>
           <li><a href="#coaching_build_a_team">Coaching: Build a Team</a></li>
           <li><a href="#coaching_dynamics_ideas">Coaching Dynamics (Ideas)</a></li>
-          <li><a href="#discussion_comprehension">Discussion: Comprehension</a></li>
+          <li><a href="#the_curriculum">The Curriculum</a></li>
+          <li><a href="#some_people_are_trialing_a_new_curriculum">Some people are trialing a new Curriculum</a></li>
           <li><a href="#practical_recap">Practical Recap</a></li>
         </ul>
       </div>

--- a/coaches_training.deck.html
+++ b/coaches_training.deck.html
@@ -535,7 +535,7 @@ Floating coaches are available for extra support.</p>
 
 </section>
     <section class="slide" id="some_people_are_trialing_a_new_curriculum">
-<h2>Some people are trialing a new Curriculum</h2>
+<h2>Some people are trialing a new curriculum</h2>
 
 <p>But everyone should still install NightCode for now</p>
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+with (import <nixpkgs> {});
+let
+  gems = bundlerEnv {
+    name = "clojurebridge-website";
+    inherit ruby;
+    gemdir = ./.;
+  };
+in stdenv.mkDerivation {
+  name = "clojurebridge-website";
+  buildInputs = [gems ruby];
+}

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -227,22 +227,6 @@ DISCUSS!
 * please don't assume anybody's gender
 * refrain from gender specific terms like "hey guys", "hello ladies"
 
-# Social Comfort (Even More Ideas)
-#### Represent the diverse and welcoming community we stand for
-* Don't mock other languages or technologies.
-* Leave your nerdy flame wars at the door.
-* Windows is fine. PHP is fine. Javascript is fine.
-* Be genuinely interested in people's experiences. ("You built something? That's cool. What does it do?")
-* Appreciate that different technologies have different trade-offs. Being easily accessible is one of them.
-
-# Code of Conduct Violations
-
-The Berlin Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
-
-#### Q: How do I react if an attendee complains about CoC violation?
-#### A: Bring them to an orga-team member
-
-
 # Technical Capability (Ideas)
 
 #### Being confused is normal
@@ -313,8 +297,12 @@ The Berlin Code of Conduct outlines our expectations for all those who participa
 * When you ask a question, wait TEN WHOLE SECONDS before saying anything else. People need time to think.
 * Don't let the most advanced students dictate the pacing or answer all the questions.
 
+# Code of Conduct Violations
 
+The Berlin Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 
+#### Q: How do I react if an attendee complains about CoC violation?
+#### A: Bring them to an orga-team member
 
 # Coaching: Build a Team
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -306,10 +306,9 @@ The Berlin Code of Conduct outlines our expectations for all those who participa
 
 # Coaching: Build a Team
 
-* ClojureBridge normally makes a distinction between coaches and TAs (teaching assistants).
 * We will try to form groups with two coaches per group.
 * You can decide on one coach to take the lead, or you can tag-team.
-* There will also be some "floating" TAs that can go around and help.
+* There will also be some "floating" coaches that can go around and help.
 
 # Coaching Dynamics (Ideas)
 
@@ -325,8 +324,21 @@ The Berlin Code of Conduct outlines our expectations for all those who participa
 * Co-coaches can help people who get lost.
 * If someone falls behind, the co-coach can take them aside to do some 1-on-1.
 
+# The Curriculum
+* Most people will go through the curriculum on our web page
 
+http://clojurebridge-berlin.org/curriculum
 
+### It's a slideshow that goes through the concepts of:
+* values
+* data structures
+* functions
+* control logic
+
+## Please take a look :)
+
+# Some people are trialing a new Curriculum
+But everyone should still install NightCode for now
 
 # Practical Recap
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -45,15 +45,10 @@ We're making tech more diverse and more welcoming!
 
 # Introductions
 ### Who are you?
-* What's your name?
-* What are your pronouns?
-* Have you been to a ClojureBridge or similar workshops before? How many?
-* What's your favorite place in Berlin?
-* What's the most non-coding thing you do?
+* What's your name and pronouns?
+* Have you been to a ClojureBridge or similar workshops before?
 
 # What's a ClojureBridge?
-
-Raise your hand if you've been to a workshop before!
 
 ### RailsBridge Fun Facts
 
@@ -85,7 +80,7 @@ We use the NightCode editor. Of course if people have their own preference then 
 
 NightCode is pretty easy to install, as it's just an executable JAR. We'll have a couple thumb drives to go around.
 
-Please actually create and run a Quil project, so all dependencies are downloaded and available.
+Please actually create and run a Quil project, so all dependencies are downloaded and available – this has caused problems before!
 
 #### Keep in mind:
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -89,6 +89,20 @@ Please actually create and run a Quil project, so all dependencies are downloade
 * Do NOT say bad things about Windows, even if it's frustrating.
 * If you're not sure about something, grab another volunteer.
 
+# On that note...
+
+* Don't be negative about technologies, even if you're certain they're the work of the devil
+* PHP is fine, Windows is fine, VisualBasic is fine
+* Appreciate that different technologies have different trade-offs. Being easily accessible is one of them.
+
+
+# Try to suppress your (understandable) culturally-influenced sexism
+* Don't hit on people. No sexual advances. This extends to the after-party.
+* Don't make sexist jokes. Or racist, classist, or ableist jokes. Call people out if they do. A simple "That's not funny" and moving on quickly with the conversation will often suffice.
+* Don't make gender-based generalizations ("Women are better at X, because ...")
+* Don't make references to people's bodies or state your opinion of them.
+* Don't use slurs.
+
 # Typical ClojureBridge Schedule
 
 * Friday, 6-10pm-ish: **Installfest** <br>get set up, meet the fellow attendees, with some nice food and drinks
@@ -169,12 +183,6 @@ DISCUSS!
 * Get people talking. The more comfortable they are at talking, the more likely they'll speak up when they don't understand something, or to answer someone else's question.
 
 # Social Comfort (More Ideas)
-#### Try to suppress your (understandable) culturally-influenced sexism
-* Don't hit on people. No sexual advances. None. Even at the after-party.
-* Don't make sexist jokes. Or racist, classist, or ableist jokes. Call people out if they do. A simple "That's not funny" and moving on quickly with the conversation will often suffice.
-* Don't make gender-based generalizations ("Women are better at X, because ...")
-* Don't make references to people's bodies or state your opinion of them.
-* Don't use slurs.
 
 # Social Comfort (pay attention to pronouns)
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -337,7 +337,7 @@ http://clojurebridge-berlin.org/curriculum
 
 ## Please take a look :)
 
-# Some people are trialing a new Curriculum
+# Some people are trialing a new curriculum
 But everyone should still install NightCode for now
 
 # Practical Recap

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -171,6 +171,42 @@ How to make your class awesome? We created some arbitrary categories for discuss
 
 DISCUSS!
 
+# Discussion (Do you know what's up?)
+
+#### How can you help people feel like you know what's going on?
+#### What are things you can do to help the students trust you?
+#### What are some things to avoid?
+
+DISCUSS!
+
+# Discussion: Technical Capability
+### How can you help people feel technically capable?
+### What kinds of insecurities might your student have?
+### How can you bolster their confidence?
+
+DISCUSS!
+
+# Discussion: Challenges
+Talk about what problems you might anticipate, and what to do about them.
+
+#### Some issues:
+* Student is in the wrong class level
+* Student is disruptive
+* Student is disengaged
+
+DISCUSS!
+
+# Discussion: Coaching
+
+#### What are the benefits of having two coaches in a group?
+#### How can you divide the roles between the coaches?
+#### How can you get a good dynamic between the whole team, both attendees and coaches?
+
+DISCUSS!
+
+# What we came up with
+* So now you've been through these discussions, this is what we came up with!
+
 # Social Comfort (Ideas)
 
 #### Introductions
@@ -205,14 +241,6 @@ The Berlin Code of Conduct outlines our expectations for all those who participa
 
 #### Q: How do I react if an attendee complains about CoC violation?
 #### A: Bring them to an orga-team member
-
-
-# Discussion: Technical Capability
-### How can you help people feel technically capable?
-### What kinds of insecurities might your student have?
-### How can you bolster their confidence?
-
-DISCUSS!
 
 
 # Technical Capability (Ideas)
@@ -253,14 +281,6 @@ DISCUSS!
 * Explain the big picture of a command *before* they type it in.
   * i.e., before typing the command to deploy to Heroku, explain the difference between localhost and Heroku.
 
-# Discussion (Do you know what's up?)
-
-#### How can you help people feel like you know what's going on?
-#### What are things you can do to help the students trust you?
-#### What are some things to avoid?
-
-DISCUSS!
-
 # Know What's Up (Ideas)
 #### Know what's going on
 
@@ -293,23 +313,8 @@ DISCUSS!
 * When you ask a question, wait TEN WHOLE SECONDS before saying anything else. People need time to think.
 * Don't let the most advanced students dictate the pacing or answer all the questions.
 
-# Discussion: Challenges
-Talk about what problems you might anticipate, and what to do about them.
 
-#### Some issues:
-* Student is in the wrong class level
-* Student is disruptive
-* Student is disengaged
 
-DISCUSS!
-
-# Discussion: Coaching
-
-#### What are the benefits of having two coaches in a group?
-#### How can you divide the roles between the coaches?
-#### How can you get a good dynamic between the whole team, both attendees and coaches?
-
-DISCUSS!
 
 # Coaching: Build a Team
 
@@ -332,13 +337,8 @@ DISCUSS!
 * Co-coaches can help people who get lost.
 * If someone falls behind, the co-coach can take them aside to do some 1-on-1.
 
-# Discussion: Comprehension
 
-#### How can you tell if they understand the words you're saying?
-#### What are good questions to ask to check comprehension?
-#### What did your favorite coaches do to gauge understanding?
 
-DISCUSS!
 
 # Practical Recap
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -20,7 +20,7 @@ It helps to have a whiteboard or those giant sticky notes for the discussions if
 
 # Code of Conduct
 
-The Berlin Code of Conduct ([berlincodeofconduct.org](berlincodeofconduct.org))  outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+The Berlin Code of Conduct ([berlincodeofconduct.org](berlincodeofconduct.org)) outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 
 ### Expected Behavior
 
@@ -228,7 +228,6 @@ DISCUSS!
 * Remember people's backgrounds (Javascript, Ruby, Java, HTML/CSS,) and relate where possible.
 * Don't be afraid to use metaphors. If they are a cook, try a cooking analogy.
 
-
 # Technical Capability (More Ideas)
 #### Encourage collaboration and interaction
 * Explicitly encourage students to try to answer each other's questions.
@@ -241,7 +240,6 @@ DISCUSS!
 * If they aren't getting a concept, avoid anything that might shame them.
 * Don't be surprised when someone hasn't heard of something before.
 * Don't grab anyone's keyboard. Avoid taking over unless you think it's *really* necessary. Ask before you do. "Mind if I drive for a sec?" But really, don't.
-
 
 # Technical Capability (Even More Ideas)
 

--- a/docs/coaches_training.deck.md
+++ b/docs/coaches_training.deck.md
@@ -47,6 +47,7 @@ We're making tech more diverse and more welcoming!
 ### Who are you?
 * What's your name and pronouns?
 * Have you been to a ClojureBridge or similar workshops before?
+* What's your current favourite restaurant?
 
 # What's a ClojureBridge?
 
@@ -334,6 +335,8 @@ http://clojurebridge-berlin.org/curriculum
 * data structures
 * functions
 * control logic
+
+* Then followed by people playing with graphical programming in Quil
 
 ## Please take a look :)
 

--- a/gemset.nix
+++ b/gemset.nix
@@ -1,0 +1,253 @@
+{
+  coderay = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x6z923iwr1hi04k6kz5a6llrixflz8h5sskl9mhaaxy9jx2x93r";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  colorator = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09zp15hyd9wlbgf1kmrf4rnry8cpvh1h9fj7afarlqcy4hrfdpvs";
+      type = "gem";
+    };
+    version = "0.1";
+  };
+  daemons = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b839hryy9sg7x3knsa1d6vfiyvn0mlsnhsb6an8zsalyrz1zgqg";
+      type = "gem";
+    };
+    version = "1.2.3";
+  };
+  deckrb = {
+    dependencies = ["coderay" "erector" "json" "nokogiri" "rack" "rack-codehighlighter" "redcarpet" "thin" "trollop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16qryjk7fvx6p2wcqyk53zj10gbn8z3p38clhqwd42m4ps0v0ckp";
+      type = "gem";
+    };
+    version = "0.5.2";
+  };
+  erector = {
+    dependencies = ["treetop"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rv5l4wfx8737arxaknh4lhlf5pvmlbps7dbjc4vr35j36sfpz9i";
+      type = "gem";
+    };
+    version = "0.10.0";
+  };
+  eventmachine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wgvhzi27zcszp0gbybvmkxby3wxkrwlkicrjrlyidcj6jz6agd2";
+      type = "gem";
+    };
+    version = "1.2.0.1";
+  };
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1m5mprppw0xcrv2mkim5zsk70v089ajzqiq5hpyb0xg96fcyzyxj";
+      type = "gem";
+    };
+    version = "1.9.10";
+  };
+  jekyll = {
+    dependencies = ["colorator" "jekyll-sass-converter" "jekyll-watch" "kramdown" "liquid" "mercenary" "rouge" "safe_yaml"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l1kq96bps29sx1cawbn4p9al4cljkywlr02zwgbcdwrr0211rhp";
+      type = "gem";
+    };
+    version = "3.1.6";
+  };
+  jekyll-sass-converter = {
+    dependencies = ["sass"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "095757w0pg6qh3wlfg1j1mw4fsz7s89ia4zai5f2rhx9yxsvk1d8";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  jekyll-watch = {
+    dependencies = ["listen"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15imgkfdzvbsz159bc2aa7a21x3379licrij5g0sdid8bs9rxd4a";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nsby6ry8l9xg3yw4adlhk2pnc7i0h0rznvcss4vk3v74qg0k8lc";
+      type = "gem";
+    };
+    version = "1.8.3";
+  };
+  kramdown = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05ljwi07hjjwgnjg19sg8mkyxf1an5xn8kn1717d5qrrqkzn3zq1";
+      type = "gem";
+    };
+    version = "1.11.1";
+  };
+  liquid = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "033png37ym4jrjz5bi7zb4ic4yxacwvnllm1xxmrnr4swgyyygc2";
+      type = "gem";
+    };
+    version = "3.0.6";
+  };
+  listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l0y7hbyfiwpvk172r28hsdqsifq1ls39hsfmzi1vy4ll0smd14i";
+      type = "gem";
+    };
+    version = "3.0.8";
+  };
+  mercenary = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10la0xw82dh5mqab8bl0dk21zld63cqxb1g16fk8cb39ylc4n21a";
+      type = "gem";
+    };
+    version = "0.3.6";
+  };
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y25adxb1hgg1wb2rn20g3vl07qziq6fz364jc5694611zz863hb";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2" "pkg-config"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17pjhvm4yigriizxbbpx266nnh6nckdm33m3j4ws9dcg99daz91p";
+      type = "gem";
+    };
+    version = "1.6.8";
+  };
+  pkg-config = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lljiqnm0b4z6iy87lzapwrdfa6ps63x2z5zbs038iig8dqx2g0z";
+      type = "gem";
+    };
+    version = "1.1.7";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      type = "gem";
+    };
+    version = "1.6.4";
+  };
+  rack-codehighlighter = {
+    dependencies = ["nokogiri" "rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00mmprszba2wry4jybj72fms44yk908s3clfd5hqipnhyy8d4rgk";
+      type = "gem";
+    };
+    version = "0.5.1";
+  };
+  rb-fsevent = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xlkflgxngwkd4nyybccgd1japrba4v3kwnp00alikj404clqx4v";
+      type = "gem";
+    };
+    version = "0.9.7";
+  };
+  rb-inotify = {
+    dependencies = ["ffi"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yfcp3065n08balljmxn0qzwhdbwwxn2h9z89wmydyfj2gq1p71d";
+      type = "gem";
+    };
+    version = "0.9.7";
+  };
+  redcarpet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fghh7n9kz6n6bdhgix5s8lyj5sw6q44zizf4mdgz5xsgwqcr6sw";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  rouge = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h2z42vm84kj8q2rv7hhhqbavhpwig6acyz2ghzfy4bjmv0yyaik";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  safe_yaml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hly915584hyi9q9vgd968x2nsi5yag9jyf5kq60lwzi5scr7094";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  sass = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dkj6v26fkg1g0majqswwmhxva7cd6p3psrhdlx93qal72dssywy";
+      type = "gem";
+    };
+    version = "3.4.22";
+  };
+  thin = {
+    dependencies = ["daemons" "eventmachine" "rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dq9q7qyjyg4444bmn12r2s0mir8dqnvc037y0zidhbyaavrv95q";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  treetop = {
+    dependencies = ["polyglot"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lg7j8xf8yxmnz1v8zkwhs4l6j30kq2pxvvrvpah2frlaqz077dh";
+      type = "gem";
+    };
+    version = "1.6.5";
+  };
+  trollop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0415y63df86sqj43c0l82and65ia5h64if7n0znkbrmi6y0jwhl8";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+}


### PR DESCRIPTION
Main changes:
1) Reduced intro round
2) Put "no sexism" and "don't insult people's tech" stuff out from the discussions to near the beginning
3) Changing order of the discussions, the questions at the beginning all together, the ideas/answers separately
   * This is in order to get people to come up with them in smaller groups on paper, then check how they compare to our answers afterwards
4) Move CoC violation into "Know what's up" ideas/answers
5) Add a little placeholder about the curriculum