### PR TITLE
Learning group reorg

### DIFF
--- a/learners_group.html
+++ b/learners_group.html
@@ -9,87 +9,19 @@ permalink: /learners-group/
     <div class="row">
       <h2>Clojure Berlin Learning Group</h2>
       <div class="col-md-6 space-below">
-        <p>
-          <b>English: </b>
-        </p>
-        <p>
-        <i>
-          The learning group is a collective of women and non-binary people interested in programming. We meet one evening a week to learn Clojure, facilitated by coaches (of various genders).
-        </i>
-        </p>
-        <p>Looking to start or continue learning Clojure?
-        </br>
-        Join the Learning group!</p>
-        <p>Beginners are absolutely welcome,
-          if you have done the workshop you know more than enough.<br> Even if you haven't done the workshop there are
-          plenty of other learners who are more than happy to help you get started.
-        </p>
+        <h4>English</h4>
+        <p>Looking to start or continue learning Clojure? Join the Learning group!</p>
+        <p>We meet every Wednesday of every month <em>except</em> for the second Wednesday (that's when we go to the Clojure Meetup), at <a href="https://www.facebook.com/pfeifferscafe/">Pfeiffer's Cafe</a> in Kreuzberg.</p>
+        <p>Coaches and fellow learners are there to help you. Folks work on either their own independent projects or guided curriculum.</p>
+        <p>The learning group follows the <a href="http://berlincodeofconduct.org/">Berlin code of conduct</a>.
       </div>
 
       <div class="col-md-6">
-        <p>
-          <b>Deutsch: </b>
-        </p>
-        <p>
-        <i>
-          Die Lerngruppe ist ein Kollektiv von Frauen und nichtbinären Menschen, die am Programmieren lernen interessiert sind. Wir treffen uns einen Abend in der Woche. Mit dabei sind Coaches (verschiedenen Genders), die uns zur Unterstützung stehen.
-        </i>
-        </p>
-        <p>Du möchtest anfangen Clojure zu lernen oder damit weitermachen?
-        </br>
-        Werde Teil unserer Lerngruppe!</p>
-        <p>Anfänger_innen sind absolut willkommen, falls du am Workshop teilgenommen hast weißt du mehr als genug.<br>
-          Selbst wenn du nicht beim Workshop warst sind genug andere Lernende da, die dir gern dabei helfen können loszulegen.
-        </p>
-      </div>
-    </div>
-
-    <div class="row bottom-space">
-      <div class="col-md-6">
-        <p><b>Learning Group Facts:</b></p>
-        <ul>
-          <li>
-            <p>Location: <a href="http://co-up.de/about.html" title="co-up about">co-up coworking space</a> 3rd floor <br>near U8/U1 Kottbusser Tor.<br>
-              <a href="http://co-up.de/code-of-conduct.html" title="co-up coc">Code of Conduct</a>, <a href="http://co-up.de/space-instructions.html" title="co-up location">Location/ accessibility info</a></p>
-          </li>
-          <li>
-            <p>When: Every Wednesday of every month except for the second Wednesday (that's when we go to the Clojure Meetup)</p>
-          </li>
-          <li>
-            <p>What: You can either work on your own stuff, or find people with shared interests and work together on a project over a longer period of time</p>
-          </li>
-          <li>
-            <p>Our Code of Conduct: <a href="http://berlincodeofconduct.org/">Please read here</a></p>
-          </li>
-          <li>
-            <p>There will be coaches to help you along</p>
-          </li>
-        </ul>
-      </div>
-
-      <div class="col-md-6">
-        <p><b>Learning Group Fakten:</b></p>
-        <ul>
-          <li>
-            <p>Ort: <a href="http://co-up.de/about.html" title="co-up about">co-up coworking space</a> 3. Etage<br>nahe U8/U1 Kottbusser Tor.<br>
-              <a href="http://co-up.de/code-of-conduct.html" title="co-up coc">Verhaltensregeln</a>, <a href="http://co-up.de/space-instructions.html" title="co-up location">Standort/ Barrierefreiheitsinfo</a></p>
-          </li>
-          <li>
-            <p>Wann: Jeden Mittwoch im Monat außer am zweiten Mittwoch (dann gehen wir zum Clojure Meetup)</p>
-          </li>
-          <li>
-            <p>Was: Du kannst entweder auf eigene Faust arbeiten oder Menschen mit gemeinsamen Interessen finden und gemeinsam an einem Projekt über einen längeren Zeitraum arbeiten</p>
-          </li>
-          <li>
-            <p>Unsere Code of Conduct: <a href="http://berlincodeofconduct.org/">Bitte Hier lesen</a></p>
-          </li>
-          <li>
-            <p>Wir beginnen die Lerngruppe mit einem veganen Abendessen, bei dem alle etwas mitbringt (engl. Potluck), du kannst gern auch eine Kleinigkeit mitbringen und mit den anderen teilen.</p>
-          </li>
-          <li>
-            <p>Ein paar Coaches sind da um dir zu helfen</p>
-          </li>
-        </ul>
+        <h4>Deutsch</h4>
+        <p>Du möchtest anfangen Clojure zu lernen oder damit weitermachen? Werde Teil unserer Lerngruppe!</p>
+        <p>Wir treffen jeden Mittwoch im Monat <em>außer</em> am zweiten Mittwoch (dann gehen wir zum Clojure Meetup) um <a href="https://www.facebook.com/pfeifferscafe/">Pfeiffer's Cafe</a> in Kreuzberg.</p>
+        <p>Ein paar Coaches sind da um dir zu helfen.</p>
+        <p>Bitte Hier lesen unsere <a href="http://berlincodeofconduct.org/">code of conduct</a>.<p>
       </div>
     </div>
   </div>

--- a/learners_group.html
+++ b/learners_group.html
@@ -1,25 +1,25 @@
 ---
 layout: default
-title: Clojure Dojo Workshops
+title: Clojure Berlin Learning Group
 permalink: /learners-group/
 ---
 
 <section class="module content">
   <div class="container">
     <div class="row">
-      <h2>Clojure Dojo Learners Group</h2>
+      <h2>Clojure Berlin Learning Group</h2>
       <div class="col-md-6 space-below">
         <p>
           <b>English: </b>
         </p>
         <p>
         <i>
-          The learning group is a collective of women and non binary people interested in programming. We meet one evening a week to learn Clojure, facilitated by coaches (of various genders).
+          The learning group is a collective of women and non-binary people interested in programming. We meet one evening a week to learn Clojure, facilitated by coaches (of various genders).
         </i>
         </p>
         <p>Looking to start or continue learning Clojure?
         </br>
-        Join the Learners group!</p>
+        Join the Learning group!</p>
         <p>Beginners are absolutely welcome,
           if you have done the workshop you know more than enough.<br> Even if you haven't done the workshop there are
           plenty of other learners who are more than happy to help you get started.
@@ -46,14 +46,14 @@ permalink: /learners-group/
 
     <div class="row bottom-space">
       <div class="col-md-6">
-        <p><b>Learners Group Facts:</b></p>
+        <p><b>Learning Group Facts:</b></p>
         <ul>
           <li>
             <p>Location: <a href="http://co-up.de/about.html" title="co-up about">co-up coworking space</a> 3rd floor <br>near U8/U1 Kottbusser Tor.<br>
               <a href="http://co-up.de/code-of-conduct.html" title="co-up coc">Code of Conduct</a>, <a href="http://co-up.de/space-instructions.html" title="co-up location">Location/ accessibility info</a></p>
           </li>
           <li>
-            <p>When: Every Wednesdays of every month except for the second Wednesday (that's when we go to the Clojure Meetup)</p>
+            <p>When: Every Wednesday of every month except for the second Wednesday (that's when we go to the Clojure Meetup)</p>
           </li>
           <li>
             <p>What: You can either work on your own stuff, or find people with shared interests and work together on a project over a longer period of time</p>
@@ -62,16 +62,13 @@ permalink: /learners-group/
             <p>Our Code of Conduct: <a href="http://berlincodeofconduct.org/">Please read here</a></p>
           </li>
           <li>
-            <p>Evenings start with a vegan potluck, so feel free to bring and share some food</p>
-          </li>
-          <li>
             <p>There will be coaches to help you along</p>
           </li>
         </ul>
       </div>
 
       <div class="col-md-6">
-        <p><b>Learners Group Fakten:</b></p>
+        <p><b>Learning Group Fakten:</b></p>
         <ul>
           <li>
             <p>Ort: <a href="http://co-up.de/about.html" title="co-up about">co-up coworking space</a> 3. Etage<br>nahe U8/U1 Kottbusser Tor.<br>


### PR DESCRIPTION
I made major changes to the Learner's group page. Please review the language carefully.

 - new venue
 - unify terminology (except in the URL) to "Learning Group"
 - no potluck
 - less explicit beginners-welcome
 - removed "collective of women and non binary people"

I attempted to translate the German myself. I am fully aware how terrible an idea that is. Please assist.